### PR TITLE
Use sudo if necessary

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -129,7 +129,9 @@ commands:
               exit 0
             fi
 
-            sudo npm install -g coveralls
+            if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
+
+            $SUDO npm install -g coveralls
 
             if [ ! $COVERALLS_REPO_TOKEN ]; then
               export COVERALLS_REPO_TOKEN=<< parameters.token >>


### PR DESCRIPTION
Idea copied from https://circleci.com/orbs/registry/orb/circleci/build-tools

Am currently getting
```
/bin/bash: line 6: sudo: command not found
Exited with code 127
CircleCI received exit code 127
```
https://app.circleci.com/jobs/github/RoundingWell/care-ops-frontend/2728