### PR TITLE
Use build num instead of workflow id

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -132,7 +132,7 @@ commands:
           command: |
             if << parameters.parallel_finished >>; then
               curl "<< parameters.coveralls_endpoint >>/webhook?repo_token=$<< parameters.token >>" \
-                -d "payload[build_num]=$CIRCLE_WORKFLOW_ID&payload[status]=done"
+                -d "payload[build_num]=$CIRCLE_BUILD_NUM&payload[status]=done"
               exit 0
             fi
 


### PR DESCRIPTION
The current setup is misleading. 
It is showing on coveralls as the build number, but in reality it is the workflow id of the build
Built in CircleCI env variables [here](https://circleci.com/docs/2.0/env-vars/?utm_source=google&utm_medium=sem&utm_campaign=sem-google-dg--emea-en-dsa-maxConv-auth-nb&utm_term=g_b-_c__dsa_&utm_content=&gclid=Cj0KCQjwrJOMBhCZARIsAGEd4VEr2_WZ6lTetuz6uUOll3UjDzUm_nC77lsl2cRD-EvExnGbrTKbYlQaAnhgEALw_wcB#built-in-environment-variables)

![Screenshot 2021-11-05 at 18 16 02](https://user-images.githubusercontent.com/13778631/140559243-926de0db-332c-4b38-bd64-802492e4eb03.png)

I think it would be much nicer to see `1` rather than `611d45e9-ed30-4eda-bff0-60130de2e8af`
