### PR TITLE
Fix false parallel parameter value to a string for CircleCI

### DIFF
--- a/src/scripts/coveralls.sh
+++ b/src/scripts/coveralls.sh
@@ -28,6 +28,12 @@ if [ "${COVERALLS_DONE}" == "1" ]; then
   exit 0
 fi
 
+# CircleCI may coerce a boolean false value to 0, but the coverage reporter
+# expects the exact string "false"
+if [ "${COVERALLS_PARALLEL}" == "0" ]; then
+  COVERALLS_PARALLEL="false"
+fi
+
 # Check for coverage file presence
 if [ -n "${COVERALLS_COVERAGE_FILE}" ]; then
   if [ -r "${COVERALLS_COVERAGE_FILE}" ]; then


### PR DESCRIPTION
Hi, I'm not sure if this is the right place to report this bug vs. the [coverage reporter](https://github.com/coverallsapp/coverage-reporter), but the starting point is a CircleCI configuration using this orb.

## Problem

The boolean parameter `parallel` in the [CircleCI configuration](https://github.com/coverallsapp/orb/blob/f9b631db7ef9e8ca4fc0e79422c2d3882435ec5b/src/%40orb.yml#L109) does not work as expected, due to conversion to 0/1 by CircleCI.

Per [CircleCI docs](https://circleci.com/docs/reusing-config/#boolean), a boolean field may be converted to 0/1, which is what appears to be happening in this case.

So given `parallel: false` (or unset, as in the [example simple config](https://circleci.com/developer/orbs/orb/coveralls/coveralls?version=2.1.0#usage-simple)), the environment variable `COVERALLS_PARALLEL` is set to `0`, which fails the [test in the coverage reporter](https://github.com/coverallsapp/coverage-reporter/blob/8a6ea39858c9e659839d73fad302540c79740570/src/coverage_reporter/cli/cmd.cr#L91) used for determining if parallel mode is enabled.

This changeset forces the value 0 back to the string "false" to satisfy the test in the coverage reporter.

## Limitations

This hack is not exhaustive as it 1) only modifies the false value and 2) doesn't inspect any other boolean parameters. A better fix might be for the coverage reporter to treat the value `0` as false.

## Steps to reproduce

1. Create a job using the simple example, with or without specifying `parallel: false`
2. Observe the output from the `coveralls/upload` step and notice the reference to parallel mode:

```
Running in parallel mode. You must call the webhook after all jobs finish: `coveralls --done`
```
3. Observe that the report doesn't appear in coveralls because the finalization step (`--done`) was never performed

## Sample CircleCI project configuration

```yaml
version: 2.1
jobs:
  test:
    docker:
      - image: cimg/go:1.19
    steps:
      - run:
          name: create coverage file
          command: |
            echo 'mode: set' > cover.out
            echo 'github.com/abc/123/root.go:42.62,47.2 1 1' >> cover.out
      - coveralls/upload:
          coverage_file: cover.out
          parallel: false
          dry_run: true
          verbose: true

orbs:
  coveralls: coveralls/coveralls@2.1.0

workflows:
  version: 2
  on-commit:
    jobs:
      - test
```

Output:

```sh
Parsing args
Dry run - 1
Reporting coverage
+ ./coveralls --debug --dry-run --file cover.out
 
⠀⠀⠀⠀⠀⠀⣿
⠀⠀⠀⠀⠀⣼⣿⣧⠀⠀⠀⠀⠀⠀⠀ ⣠⣶⣾⣿⡇⢀⣴⣾⣿⣷⣆ ⣿⣿⠀⣰⣿⡟⢸⣿⣿⣿⡇ ⣿⣿⣿⣷⣦⠀⠀⢠⣿⣿⣿⠀⠀⣿⣿⠁⠀⣼⣿⡇⠀⢀⣴⣾⣿⡷
⠶⣶⣶⣶⣾⣿⣿⣿⣷⣶⣶⣶⠶  ⣸⣿⡟ ⠀⢠⣿⣿⠃⠈⣿⣿⠀⣿⣿⢠⣿⡿⠀⣿⣿⣧⣤⠀⢸⣿⡇⣠⣿⡿⠀⢠⣿⡟⣿⣿⠀⢸⣿⡿⠀⠀⣿⣿⠃⠀⢸⣿⣧⣄
⠀⠀⠙⢻⣿⣿⣿⣿⣿⡟⠋⠁⠀⠀ ⣿⣿⡇⠀ ⢸⣿⣿⠀⣸⣿⡟⠀⣿⣿⣾⡿⠁ ⣿⣿⠛⠛⠀⣿⣿⢿⣿⣏⠀⢀⣿⣿⣁⣿⣿⠀⣾⣿⡇⠀⢸⣿⡿⠀⠀⡀⠙⣿⣿⡆
⠀⠀⢠⣿⣿⣿⠿⣿⣿⣿⡄⠀⠀⠀ ⠙⢿⣿⣿⠇⠈⠿⣿⣿⡿⠋⠀⠀⢿⣿⡿⠁⠀⢸⣿⣿⣿⡇⢸⣿⣿⠀⣿⣿⣄⣾⣿⠛⠛⣿⣿⢠⣿⣿⣿ ⣼⣿⣿⣿ ⣿⣿⡿⠋⠀
⠀⢀⣾⠟⠋⠀⠀⠀⠙⠻⣷⡀⠀⠀
 
  v0.3.0

📄 Using coverage file: cover.out
☝️ Detected coverage format: golang
⭐️ Running in parallel mode. You must call the webhook after all jobs finish: `coveralls --done`
🚀 Posting coverage data to https://coveralls.io/api/v1/jobs
---
⛑ Debug Output:
{
  "service_pull_request": "606",
...
  "parallel": true,
...
```