### PR TITLE
fix: expand paths before checking for existence

### DIFF
--- a/src/scripts/coveralls.sh
+++ b/src/scripts/coveralls.sh
@@ -33,18 +33,19 @@ fi
 
 # Check for coverage file presence
 if [ -n "${COVERALLS_COVERAGE_FILE}" ]; then
-  if [ ! -e "${COVERALLS_COVERAGE_FILE}" ]; then
+  _COVERALLS_COVERAGE_FILE="$(readlink -f "$COVERALLS_COVERAGE_FILE")"
+  if [ ! -e "${_COVERALLS_COVERAGE_FILE}" ]; then
     echo "Please specify a valid 'coverage_file' parameter. File doesn't exist. Filename: ${COVERALLS_COVERAGE_FILE}"
     exit 1
-  elif [ ! -r "${COVERALLS_COVERAGE_FILE}" ]; then
+  elif [ ! -r "${_COVERALLS_COVERAGE_FILE}" ]; then
     echo "Please specify a valid 'coverage_file' parameter. File is not readable. Filename: ${COVERALLS_COVERAGE_FILE}"
     exit 1
-  elif [ ! -f "${COVERALLS_COVERAGE_FILE}" ]; then
+  elif [ ! -f "${_COVERALLS_COVERAGE_FILE}" ]; then
     echo "Please specify a valid 'coverage_file' parameter. File specified is not a regular file. Filename: ${COVERALLS_COVERAGE_FILE}"
     exit 1
-  else
-    args="${args} --file ${COVERALLS_COVERAGE_FILE}"
   fi
+
+  args="${args} --file ${_COVERALLS_COVERAGE_FILE}"
 fi
 
 if [ -n "${COVERALLS_BASE_PATH}" ]; then


### PR DESCRIPTION
Without this, all characters in the `coverage_file` value are treated as literal characters in the path. The combinations of `~`, `./`, or `../` won't be treated as expected, causing weird build failures for users.

Note that if the file doesn't exist, then the path will resolve to empty string, which is fine.

Aside, I used a separate variable so that the logging would reflect the originally passed in value and not the resolved path.

Closes #33