### PR TITLE
feat: add new options

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -19,11 +19,12 @@ jobs:
       - coveralls/upload:
           dry_run: true
           verbose: true
+          measure: true
       - coveralls/upload:
-          dry_run: true
           verbose: true
           parallel: true
           coverage_file: test/main.c.gcov
+          fail_on_error: false
       - coveralls/upload:
           dry_run: true
           verbose: true

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -22,6 +22,11 @@ commands:
           This is the file that will be sent to the Coveralls API.
         type: string
         default: ''
+      coverage_files:
+        description: >
+          Space-separated list of coverage reports to be uploaded.
+        type: string
+        default: ''
       coverage_format:
         description: >
           Force coverage report format. If not specified coveralls will try
@@ -94,6 +99,14 @@ commands:
         description: Commit SHA to compare coverage with.
         type: string
         default: ''
+      measure:
+        description: Enable time measurement logging
+        type: boolean
+        default: false
+      fail_on_error:
+        description: Whether to fail (exit code 1) on parsing or upload issues
+        type: boolean
+        default: true
     steps:
       - run:
           name: Upload Coverage Result To Coveralls
@@ -104,6 +117,7 @@ commands:
             COVERALLS_REPO_TOKEN_ENV: << parameters.token >>
             COVERALLS_VERBOSE: << parameters.verbose >>
             COVERALLS_COVERAGE_FILE: << parameters.coverage_file >>
+            COVERALLS_COVERAGE_FILES: << parameters.coverage_files >>
             COVERALLS_CARRYFORWARD_FLAGS: << parameters.carryforward >>
             COVERALLS_FLAG_NAME: << parameters.flag_name >>
             COVERALLS_PARALLEL: << parameters.parallel >>
@@ -111,5 +125,7 @@ commands:
             COVERALLS_COMPARE_REF: << parameters.compare_ref >>
             COVERALLS_COMPARE_SHA: << parameters.compare_sha >>
             COVERALLS_COVERAGE_FORMAT: << parameters.coverage_format >>
+            COVERALLS_MEASURE: << parameters.measure >>
+            COVERALLS_FAIL_ON_ERROR: << parameters.fail_on_error >>
             COVERALLS_SOURCE_HEADER: circleci-orb
           command: <<include(scripts/coveralls.sh)>>

--- a/src/scripts/coveralls.sh
+++ b/src/scripts/coveralls.sh
@@ -20,6 +20,14 @@ if [ -z "${COVERALLS_REPO_TOKEN}" ]; then
   export COVERALLS_REPO_TOKEN=$(printenv "${COVERALLS_REPO_TOKEN_ENV}")
 fi
 
+if [ "${COVERALLS_MEASURE}" == "1" ]; then
+  args="${args} --measure"
+fi
+
+if [ "${COVERALLS_FAIL_ON_ERROR}" != "1" ]; then
+  args="${args} --no-fail"
+fi
+
 if [ "${COVERALLS_DONE}" == "1" ]; then
   echo "Reporting parallel done"
 
@@ -54,6 +62,10 @@ if [ -n "${COVERALLS_COVERAGE_FILE}" ]; then
   fi
 
   args="${args} ${coverage_file}"
+fi
+
+if [ -n "${COVERALLS_COVERAGE_FILES}" ]; then
+  args="${args} ${COVERALLS_COVERAGE_FILES}"
 fi
 
 echo "Reporting coverage"


### PR DESCRIPTION
New options:

- `fail_on_error` - default: `true`, set to `false` if you don't want coverage upload issue to fail your CI.
- `measure` - default: `false`, set to `true` if you want to see time measurement logging.
- `coverage_files` - the same as `coverage_file` but can be used to provide either a space-separated list of coverage reports or a glob for them.