### PR TITLE
feat: add create_build option

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -107,6 +107,11 @@ commands:
         description: Whether to fail (exit code 1) on parsing or upload issues
         type: boolean
         default: true
+      create_build:
+        description: >
+          Create a build on parallel_finished request if it doesn't exist
+        type: boolean
+        default: false
     steps:
       - run:
           name: Upload Coverage Result To Coveralls
@@ -127,5 +132,6 @@ commands:
             COVERALLS_COVERAGE_FORMAT: << parameters.coverage_format >>
             COVERALLS_MEASURE: << parameters.measure >>
             COVERALLS_FAIL_ON_ERROR: << parameters.fail_on_error >>
+            COVERALLS_CREATE_BUILD: << parameters.create_build >>
             COVERALLS_SOURCE_HEADER: circleci-orb
           command: <<include(scripts/coveralls.sh)>>

--- a/src/scripts/coveralls.sh
+++ b/src/scripts/coveralls.sh
@@ -31,6 +31,10 @@ fi
 if [ "${COVERALLS_DONE}" == "1" ]; then
   echo "Reporting parallel done"
 
+  if [ "${COVERALLS_CREATE_BUILD}" == "1" ]; then
+    args="${args} --create-build"
+  fi
+
   set -x
 
   # shellcheck disable=SC2086


### PR DESCRIPTION
This option (`create_build`) is useful if you want to report a build and carry-forward all flags from previous build. For example, using the following configuration:

```yml
# .circleci/config.yml

...

- coveralls/upload:
  parallel_finished: true
  create_build: true
  carryforward: all
```