### PR TITLE
fix: Ensure that `coveralls report` command succeeds when `fail_on_error: false` is set

### DIFF
--- a/src/scripts/coveralls.sh
+++ b/src/scripts/coveralls.sh
@@ -73,3 +73,10 @@ echo "Reporting coverage"
 set -x
 # shellcheck disable=SC2086
 ./coveralls report $args
+set +x
+
+exit_status=$?
+if [ "${COVERALLS_FAIL_ON_ERROR}" != "1" ]; then
+  exit_status=0
+fi
+exit "${exit_status}"


### PR DESCRIPTION
Previously, if the `coveralls.sh` script fails to download the coverage reporter, running `coveralls report` resulted in a command-not-found error (error code 127). This failure once occurred multiple times over the course of a day for me, so it's not not just a theoretical concern.

Fixes https://github.com/coverallsapp/orb/issues/40.