### PR TITLE
Extend the `fail_on_error` option's behavior to setup failures like downloading, verifying and finding the `coveralls` binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 setup: true
 orbs:
-  orb-tools: circleci/orb-tools@12.0.3
-  shellcheck: circleci/shellcheck@3.1
+  orb-tools: circleci/orb-tools@12.1
+  shellcheck: circleci/shellcheck@3.2
 
 filters: &filters
   tags:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,7 +1,7 @@
 ---
 version: 2.1
 orbs:
-  orb-tools: circleci/orb-tools@12.0.3
+  orb-tools: circleci/orb-tools@12.1
 filters: &filters
   tags:
     only: /.*/


### PR DESCRIPTION
## Fixes

- #40 

### Description

Make sure the `fail_on_error` option also applies to **setup tasks**: 

- Failures to download or verify the binary; or 
- Failures to find the downloaded binary

Rather than just to failures of the **coveralls commands**:

- `coveralls report`; or 
- `coveralls done`

### To Do

- [x] Make sure `fail_on_error` option applies to any failures to download or verify the binary
- [x] Make sure `fail_on_error` option applies to any failures to find the downloaded binary in the environment