### PR TITLE
Add `coverage_reporter_version` parameter. 

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -14,15 +14,48 @@ jobs:
     steps:
       - checkout
       - coveralls/upload:
+          name: Test default version
           dry_run: true
           verbose: true
           measure: true
       - coveralls/upload:
+          name: Test latest version
+          dry_run: true
+          verbose: true
+          measure: true
+          coverage_reporter_version: latest
+      - coveralls/upload:
+          name: Test specific version
           verbose: true
           parallel: true
           coverage_file: test/main.c.gcov
+          coverage_reporter_version: v0.6.9
           fail_on_error: false
       - coveralls/upload:
+          name: Test invalid version
+          dry_run: true
+          verbose: true
+          coverage_reporter_version: invalid-version
+          fail_on_error: false
+      - run:
+          name: Verify coverage reporter version
+          command: |
+            INSTALLED_VERSION=$(coveralls --version | awk '{print $NF}')
+            EXPECTED_VERSION="<< parameters.coverage_reporter_version >>"
+            GITHUB_RELEASES_URL="https://github.com/coverallsapp/coverage-reporter/releases"
+
+            if [ "$EXPECTED_VERSION" = "latest" ]; then
+              echo "The version of coverage reporter chosen was 'latest' and the version installed is $INSTALLED_VERSION."
+              echo "Please check releases at $GITHUB_RELEASES_URL to ensure this is the latest release."
+            elif [ "$INSTALLED_VERSION" = "$EXPECTED_VERSION" ]; then
+              echo "Correct version ($EXPECTED_VERSION) installed"
+            else
+              echo "Version mismatch. Expected $EXPECTED_VERSION, but got $INSTALLED_VERSION"
+              echo "Please check releases at $GITHUB_RELEASES_URL for available versions."
+              exit 1
+            fi
+      - coveralls/upload:
+          name: Test parallel finished
           dry_run: true
           verbose: true
           parallel_finished: true

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -40,7 +40,7 @@ jobs:
       - run:
           name: Verify coverage reporter version
           command: |
-            INSTALLED_VERSION=$(coveralls --version | awk '{print $NF}')
+            INSTALLED_VERSION=$(./coveralls --version | awk '{print $NF}')
             EXPECTED_VERSION="<< parameters.coverage_reporter_version >>"
             GITHUB_RELEASES_URL="https://github.com/coverallsapp/coverage-reporter/releases"
 

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -18,25 +18,21 @@ jobs:
     steps:
       - checkout
       - coveralls/upload:
-          name: Test default version
           dry_run: true
           verbose: true
           measure: true
       - coveralls/upload:
-          name: Test latest version
           dry_run: true
           verbose: true
           measure: true
           coverage_reporter_version: latest
       - coveralls/upload:
-          name: Test specific version
           verbose: true
           parallel: true
           coverage_file: test/main.c.gcov
           coverage_reporter_version: v0.6.9
           fail_on_error: false
       - coveralls/upload:
-          name: Test invalid version
           dry_run: true
           verbose: true
           coverage_reporter_version: invalid-version
@@ -59,7 +55,6 @@ jobs:
               exit 1
             fi
       - coveralls/upload:
-          name: Test parallel finished
           dry_run: true
           verbose: true
           parallel_finished: true

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -9,6 +9,10 @@ jobs:
   command-tests:
     docker:
       - image: cimg/base:current
+    parameters:
+      coverage_reporter_version:
+        type: string
+        default: "latest"
     environment:
       COVERALLS_REPO_TOKEN: test-token
     steps:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -107,6 +107,12 @@ commands:
         description: Whether to fail (exit code 1) on parsing or upload issues
         type: boolean
         default: true
+      coverage_reporter_version:
+        type: string
+        default: "latest"
+        description: >
+          Version of coverage-reporter to use. Prefix the version number with 'v'.
+          For example: v0.6.14. Set to 'latest' for the latest version.
     steps:
       - run:
           name: Upload Coverage Result To Coveralls
@@ -127,5 +133,6 @@ commands:
             COVERALLS_COVERAGE_FORMAT: << parameters.coverage_format >>
             COVERALLS_MEASURE: << parameters.measure >>
             COVERALLS_FAIL_ON_ERROR: << parameters.fail_on_error >>
+            COVERALLS_REPORTER_VERSION: << parameters.coverage_reporter_version >>
             COVERALLS_SOURCE_HEADER: circleci-orb
-          command: <<include(scripts/coveralls.sh)>>
+          command: \<<include(scripts/coveralls.sh) \>>

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -116,7 +116,7 @@ commands:
           version.
     steps:
       - run:
-          name: Upload Coverage Result To Coveralls
+          name: Upload Coverage Results To Coveralls
           environment:
             COVERALLS_ENDPOINT: << parameters.coveralls_endpoint >>
             COVERALLS_DONE: << parameters.parallel_finished >>
@@ -136,4 +136,4 @@ commands:
             COVERALLS_FAIL_ON_ERROR: << parameters.fail_on_error >>
             COVERALLS_REPORTER_VERSION: << parameters.coverage_reporter_version >>  # yamllint disable-line rule:line-length
             COVERALLS_SOURCE_HEADER: circleci-orb
-          command: \<<include(scripts/coveralls.sh) \>>
+          command: <<include(scripts/coveralls.sh)>>

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -111,8 +111,9 @@ commands:
         type: string
         default: "latest"
         description: >
-          Version of coverage-reporter to use. Prefix the version number with 'v'.
-          For example: v0.6.14. Set to 'latest' for the latest version.
+          Version of coverage-reporter to use. Prefix the version number 
+          with 'v'. For example: v0.6.14. Set to 'latest' for the latest 
+          version.
     steps:
       - run:
           name: Upload Coverage Result To Coveralls
@@ -133,6 +134,6 @@ commands:
             COVERALLS_COVERAGE_FORMAT: << parameters.coverage_format >>
             COVERALLS_MEASURE: << parameters.measure >>
             COVERALLS_FAIL_ON_ERROR: << parameters.fail_on_error >>
-            COVERALLS_REPORTER_VERSION: << parameters.coverage_reporter_version >>
+            COVERALLS_REPORTER_VERSION: << parameters.coverage_reporter_version >>  # yamllint disable-line rule:line-length
             COVERALLS_SOURCE_HEADER: circleci-orb
           command: \<<include(scripts/coveralls.sh) \>>

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -111,8 +111,8 @@ commands:
         type: string
         default: "latest"
         description: >
-          Version of coverage-reporter to use. Prefix the version number 
-          with 'v'. For example: v0.6.14. Set to 'latest' for the latest 
+          Version of coverage-reporter to use. Prefix the version number
+          with 'v'. For example: v0.6.14. Set to 'latest' for the latest
           version.
     steps:
       - run:

--- a/src/scripts/coveralls.sh
+++ b/src/scripts/coveralls.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
+# Determine which version of coverage-reporter to download
+if [ -z "$COVERALLS_REPORTER_VERSION" ] || [ "$COVERALLS_REPORTER_VERSION" == "latest" ]; then
+  asset_path="latest/download"
+else
+  asset_path="download/${COVERALLS_REPORTER_VERSION}"
+fi
+
 # Download the Coveralls binary and verify the checksum
-if ! curl -sLO https://github.com/coverallsapp/coverage-reporter/releases/latest/download/coveralls-linux.tar.gz ||
-   ! curl -sLO https://github.com/coverallsapp/coverage-reporter/releases/latest/download/coveralls-checksums.txt ||
+if ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-linux.tar.gz" ||
+   ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-checksums.txt" ||
    ! grep coveralls-linux.tar.gz coveralls-checksums.txt | sha256sum --check ||
    ! tar -xzf coveralls-linux.tar.gz; then
   echo "Failed to download or verify coveralls binary."
@@ -16,6 +23,10 @@ if [ ! -f ./coveralls ]; then
   [ "${COVERALLS_FAIL_ON_ERROR}" != "1" ] && exit 0
   exit 1
 fi
+
+# Output the version of the installed coverage reporter
+echo "Installed coverage reporter version:"
+./coveralls --version || echo "Failed to retrieve version"
 
 echo "Parsing args"
 if [ "${COVERALLS_VERBOSE}" == "1" ]; then


### PR DESCRIPTION
Fixes #42 

## Description

Add `coverage_reporter_version` parameter. 

## To Do

- [x] Add `coverage_reporter_version` parameter and code to download specified version if not `latest`.
- [x] Modify tests to test `coverage_reporter_version` and workflow step to check the version against expected.