### PR TITLE
Add debug parameter to enable set -x-style debugging throughout entir…

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -19,22 +19,22 @@ jobs:
       - checkout
       - coveralls/upload:
           dry_run: true
-          verbose: true
+          debug: true
           measure: true
       - coveralls/upload:
           dry_run: true
-          verbose: true
+          debug: true
           measure: true
           coverage_reporter_version: latest
       - coveralls/upload:
-          verbose: true
+          debug: true
           parallel: true
           coverage_file: test/main.c.gcov
           coverage_reporter_version: v0.6.9
           fail_on_error: false
       - coveralls/upload:
           dry_run: true
-          verbose: true
+          debug: true
           coverage_reporter_version: invalid-version
           fail_on_error: false
       - run:
@@ -56,7 +56,7 @@ jobs:
             fi
       - coveralls/upload:
           dry_run: true
-          verbose: true
+          debug: true
           parallel_finished: true
 workflows:
   test-deploy:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -75,7 +75,11 @@ commands:
         type: string
         default: ''
       verbose:
-        description: Set to true for verbose output from the Coveralls API push.
+        description: Set to true for debug output. Deprecated, use debug instead.
+        type: boolean
+        default: false
+      debug:
+        description: Set to true for debug output. Replaces verbose.
         type: boolean
         default: false
       dry_run:
@@ -123,6 +127,7 @@ commands:
             COVERALLS_BASE_PATH: << parameters.base_path >>
             COVERALLS_REPO_TOKEN_ENV: << parameters.token >>
             COVERALLS_VERBOSE: << parameters.verbose >>
+            COVERALLS_DEBUG: << parameters.debug >>
             COVERALLS_COVERAGE_FILE: << parameters.coverage_file >>
             COVERALLS_COVERAGE_FILES: << parameters.coverage_files >>
             COVERALLS_CARRYFORWARD_FLAGS: << parameters.carryforward >>

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -76,7 +76,7 @@ commands:
         default: ''
       verbose:
         description: >
-        Set to true for debug output. Deprecated, use debug instead.
+          Set to true for debug output. Deprecated, use debug instead.
         type: boolean
         default: false
       debug:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -75,7 +75,8 @@ commands:
         type: string
         default: ''
       verbose:
-        description: Set to true for debug output. Deprecated, use debug instead.
+        description: >
+        Set to true for debug output. Deprecated, use debug instead.
         type: boolean
         default: false
       debug:

--- a/src/scripts/coveralls.sh
+++ b/src/scripts/coveralls.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Enable set -x debugging if COVERALLS_DEBUG or COVERALLS_VERBOSE (deprecated) is set to "1"
+if "${COVERALLS_VERBOSE}" == "1" ] || [ "${COVERALLS_DEBUG}" == "1" ]; then
+  set -x
+fi
+
 # Determine which version of coverage-reporter to download
 if [ -z "$COVERALLS_REPORTER_VERSION" ] || [ "$COVERALLS_REPORTER_VERSION" == "latest" ]; then
   asset_path="latest/download"
@@ -28,8 +33,9 @@ fi
 echo "Installed coverage reporter version:"
 ./coveralls --version || echo "Failed to retrieve version"
 
+# Pass the --debug flag to coverage-reporter if COVERALLS_DEBUG or COVERALLS_VERBOSE (deprecated) is set to "1"
 echo "Parsing args"
-if [ "${COVERALLS_VERBOSE}" == "1" ]; then
+if [ "${COVERALLS_VERBOSE}" == "1" ] || [ "${COVERALLS_DEBUG}" == "1" ]; then
   args="${args} --debug"
 fi
 

--- a/src/scripts/coveralls.sh
+++ b/src/scripts/coveralls.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Enable set -x debugging if COVERALLS_DEBUG or COVERALLS_VERBOSE (deprecated) is set to "1"
-if "${COVERALLS_VERBOSE}" == "1" ] || [ "${COVERALLS_DEBUG}" == "1" ]; then
+if [ "${COVERALLS_DEBUG}" == "1" ] || [ "${COVERALLS_VERBOSE}" == "1" ]; then
   set -x
 fi
 
@@ -35,7 +35,7 @@ echo "Installed coverage reporter version:"
 
 # Pass the --debug flag to coverage-reporter if COVERALLS_DEBUG or COVERALLS_VERBOSE (deprecated) is set to "1"
 echo "Parsing args"
-if [ "${COVERALLS_VERBOSE}" == "1" ] || [ "${COVERALLS_DEBUG}" == "1" ]; then
+if [ "${COVERALLS_DEBUG}" == "1" ] || [ "${COVERALLS_VERBOSE}" == "1" ]; then
   args="${args} --debug"
 fi
 


### PR DESCRIPTION
Fixes #36 

## Description

Add `debug` parameter to enable `set -x` style debugging throughout entire script, including setup steps. The new `debug` option will replace the `verbose` param, which is now deprecated. Until then, both `debug` and `verbose` do the same two things. They: 

1. Enable `set-x` style debugging in the script, and then 
2. Add the `--debug` flag to all `coveralls` commands to turn on verbose output from the Coveralls API.

## To Do

- [x] Add `debug` parameter.
- [x] Add note re: deprecation of `verbose` parameter.
- [x] Add code to add `set -x` to script when `debug` (or `verbose`) are set to `true`.
- [x] Add code to add `--debug` flag to `coveralls` commands when `debug` (or `verbose`) are set to `true`.
- [x] Replace `verbose` with `debug` in existing tests