### PR TITLE
Add `coverage_reporter_platform` parameter

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -87,6 +87,20 @@ jobs:
       - run:
           name: Verify coverage reporter version
           command: |
+            # Add debugging information before checking version
+            echo "Debug: Checking coveralls binary before version verification"
+            ls -l ./coveralls
+            file ./coveralls
+            echo "Debug: System architecture: $(uname -m)"
+            echo "Debug: Platform setting: ${COVERAGE_REPORTER_PLATFORM:-x86_64}"
+
+            # Try to get version with error handling
+            if ! INSTALLED_VERSION=$(./coveralls --version 2>&1); then
+              echo "Error executing coveralls binary for version check: $INSTALLED_VERSION"
+              [ "${COVERALLS_FAIL_ON_ERROR}" != "1" ] && exit 0
+              exit 1
+            fi
+
             INSTALLED_VERSION=$(./coveralls --version | awk '{print $NF}')
             EXPECTED_VERSION="<< parameters.coverage_reporter_version >>"
             GITHUB_RELEASES_URL="https://github.com/coverallsapp/coverage-reporter/releases"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -17,26 +17,61 @@ jobs:
       COVERALLS_REPO_TOKEN: test-token
     steps:
       - checkout
+      # Test with all defaults (ie. no specified version or platform)
       - coveralls/upload:
           dry_run: true
           debug: true
           measure: true
+      # Test with parallel, coverage file and fail_on_error: false
+      - coveralls/upload:
+          verbose: true
+          parallel: true
+          coverage_file: test/main.c.gcov
+          fail_on_error: false
+      # test with parallel_finished
+      - coveralls/upload:
+          dry_run: true
+          verbose: true
+          parallel_finished: true
+      # Test with specified version (latest)
       - coveralls/upload:
           dry_run: true
           debug: true
           measure: true
           coverage_reporter_version: latest
+      # Test with specified version (v0.6.14)
       - coveralls/upload:
           debug: true
           parallel: true
           coverage_file: test/main.c.gcov
-          coverage_reporter_version: v0.6.9
+          coverage_reporter_version: v0.6.14
           fail_on_error: false
+      # Test with invalid version
       - coveralls/upload:
           dry_run: true
           debug: true
           coverage_reporter_version: invalid-version
           fail_on_error: false
+      # Test with specified platform (x86_64)
+      - coveralls/upload:
+          dry_run: true
+          debug: true
+          measure: true
+          coverage_reporter_platform: x86_64
+      # Test with specified platform (aarch64)
+      - coveralls/upload:
+          dry_run: true
+          debug: true
+          measure: true
+          coverage_reporter_platform: aarch64
+      # Test with unsupported platform
+      - coveralls/upload:
+          dry_run: true
+          debug: true
+          measure: true
+          coverage_reporter_platform: unsupported
+          fail_on_error: false
+      # Verify coverage reporter version
       - run:
           name: Verify coverage reporter version
           command: |
@@ -54,10 +89,6 @@ jobs:
               echo "Please check releases at $GITHUB_RELEASES_URL for available versions."
               exit 1
             fi
-      - coveralls/upload:
-          dry_run: true
-          debug: true
-          parallel_finished: true
 workflows:
   test-deploy:
     jobs:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -41,6 +41,7 @@ jobs:
           coverage_reporter_version: latest
       # Test with specified version (v0.6.14)
       - coveralls/upload:
+          dry_run: true
           debug: true
           parallel: true
           coverage_file: test/main.c.gcov

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,10 +1,13 @@
 ---
 version: 2.1
+
 orbs:
   orb-tools: circleci/orb-tools@12.1
+
 filters: &filters
   tags:
     only: /.*/
+
 jobs:
   command-tests:
     docker:
@@ -17,28 +20,34 @@ jobs:
       COVERALLS_REPO_TOKEN: test-token
     steps:
       - checkout
+      
       # Test with all defaults (ie. no specified version or platform)
+      - coveralls/upload:
+          dry_run: true
+          verbose: true
+          measure: true
+      
+      # Test with parallel, coverage file and fail_on_error: false
+      - coveralls/upload:
+          debug: true
+          parallel: true
+          measure: true
+          coverage_file: test/main.c.gcov
+          fail_on_error: false
+      
+      # test with parallel_finished
       - coveralls/upload:
           dry_run: true
           debug: true
           measure: true
-      # Test with parallel, coverage file and fail_on_error: false
-      - coveralls/upload:
-          verbose: true
-          parallel: true
-          coverage_file: test/main.c.gcov
-          fail_on_error: false
-      # test with parallel_finished
-      - coveralls/upload:
-          dry_run: true
-          verbose: true
           parallel_finished: true
+      
       # Test with specified version (latest)
       - coveralls/upload:
           dry_run: true
           debug: true
-          measure: true
           coverage_reporter_version: latest
+      
       # Test with specified version (v0.6.14)
       - coveralls/upload:
           dry_run: true
@@ -46,30 +55,34 @@ jobs:
           parallel: true
           coverage_file: test/main.c.gcov
           coverage_reporter_version: v0.6.14
+      
       # Test with invalid version
       - coveralls/upload:
           dry_run: true
           debug: true
           coverage_reporter_version: invalid-version
           fail_on_error: false
+      
       # Test with specified platform (x86_64)
       - coveralls/upload:
           dry_run: true
           debug: true
-          measure: true
           coverage_reporter_platform: x86_64
+      
       # Test with specified platform (aarch64)
       - coveralls/upload:
           dry_run: true
           debug: true
-          measure: true
           coverage_reporter_platform: aarch64
+          fail_on_error: false
+      
       # Test with specified platform (arm64)
       - coveralls/upload:
           dry_run: true
           debug: true
-          measure: true
           coverage_reporter_platform: arm64
+          fail_on_error: false
+      
       # Verify coverage reporter version
       - run:
           name: Verify coverage reporter version
@@ -88,11 +101,28 @@ jobs:
               echo "Please check releases at $GITHUB_RELEASES_URL for available versions."
               exit 1
             fi
+  
+  # Standalone ARM test
+  arm-test:
+    machine:
+      image: ubuntu-2004:202101-01
+      arm: true
+    steps:
+      - checkout
+      # Test with aarch64 platform on ARM machine
+      - coveralls/upload:
+          dry_run: true
+          debug: true
+          coverage_reporter_platform: aarch64
+          coverage_reporter_version: v0.6.15
+
 workflows:
   test-deploy:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
       - command-tests:
+          filters: *filters
+      - arm-test:
           filters: *filters
       - orb-tools/pack:
           filters: *filters
@@ -103,6 +133,7 @@ workflows:
           requires:
             - orb-tools/pack
             - command-tests
+            - arm-test
           context: publishing
           filters:
             branches:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -45,7 +45,6 @@ jobs:
           parallel: true
           coverage_file: test/main.c.gcov
           coverage_reporter_version: v0.6.14
-          fail_on_error: false
       # Test with invalid version
       - coveralls/upload:
           dry_run: true

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -110,6 +110,12 @@ jobs:
     resource_class: arm.medium    # specify ARM resource class
     steps:
       - checkout
+      - run:
+        name: Verify architecture
+        command: |
+          echo "uname -m reports: $(uname -m)"
+          echo "arch reports: $(arch)"
+          echo "uname -a reports: $(uname -a)"
       # Test with aarch64 platform on ARM machine
       - coveralls/upload:
           dry_run: true

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -106,7 +106,8 @@ jobs:
   arm-test:
     machine:
       image: ubuntu-2004:202101-01
-      arm: true
+      docker_layer_caching: true  # optional
+    resource_class: arm.medium    # specify ARM resource class
     steps:
       - checkout
       # Test with aarch64 platform on ARM machine

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -63,13 +63,12 @@ jobs:
           debug: true
           measure: true
           coverage_reporter_platform: aarch64
-      # Test with unsupported platform
+      # Test with specified platform (arm64)
       - coveralls/upload:
           dry_run: true
           debug: true
           measure: true
-          coverage_reporter_platform: unsupported
-          fail_on_error: false
+          coverage_reporter_platform: arm64
       # Verify coverage reporter version
       - run:
           name: Verify coverage reporter version

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -110,12 +110,13 @@ jobs:
     resource_class: arm.medium    # specify ARM resource class
     steps:
       - checkout
+      # Verify ARM architecture
       - run:
-        name: Verify architecture
-        command: |
-          echo "uname -m reports: $(uname -m)"
-          echo "arch reports: $(arch)"
-          echo "uname -a reports: $(uname -a)"
+          name: Verify architecture
+          command: |
+            echo "uname -m reports: $(uname -m)"
+            echo "arch reports: $(arch)"
+            echo "uname -a reports: $(uname -a)"
       # Test with aarch64 platform on ARM machine
       - coveralls/upload:
           dry_run: true

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -82,46 +82,12 @@ jobs:
           debug: true
           coverage_reporter_platform: arm64
           fail_on_error: false
-      
-      # Verify coverage reporter version
-      - run:
-          name: Verify coverage reporter version
-          command: |
-            # Add debugging information before checking version
-            echo "Debug: Checking coveralls binary before version verification"
-            ls -l ./coveralls
-            file ./coveralls
-            echo "Debug: System architecture: $(uname -m)"
-            echo "Debug: Platform setting: ${COVERAGE_REPORTER_PLATFORM:-x86_64}"
-
-            # Try to get version with error handling
-            if ! INSTALLED_VERSION=$(./coveralls --version 2>&1); then
-              echo "Error executing coveralls binary for version check: $INSTALLED_VERSION"
-              [ "${COVERALLS_FAIL_ON_ERROR}" != "1" ] && exit 0
-              exit 1
-            fi
-
-            INSTALLED_VERSION=$(./coveralls --version | awk '{print $NF}')
-            EXPECTED_VERSION="<< parameters.coverage_reporter_version >>"
-            GITHUB_RELEASES_URL="https://github.com/coverallsapp/coverage-reporter/releases"
-
-            if [ "$EXPECTED_VERSION" = "latest" ]; then
-              echo "The version of coverage reporter chosen was 'latest' and the version installed is $INSTALLED_VERSION."
-              echo "Please check releases at $GITHUB_RELEASES_URL to ensure this is the latest release."
-            elif [ "$INSTALLED_VERSION" = "$EXPECTED_VERSION" ]; then
-              echo "Correct version ($EXPECTED_VERSION) installed"
-            else
-              echo "Version mismatch. Expected $EXPECTED_VERSION, but got $INSTALLED_VERSION"
-              echo "Please check releases at $GITHUB_RELEASES_URL for available versions."
-              exit 1
-            fi
   
   # Standalone ARM test
   arm-test:
     machine:
-      image: ubuntu-2004:202101-01
-      docker_layer_caching: true  # optional
-    resource_class: arm.medium    # specify ARM resource class
+      image: ubuntu-2204:current
+    resource_class: arm.large
     steps:
       - checkout
       # Verify ARM architecture

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -119,6 +119,11 @@ commands:
           Version of coverage-reporter to use. Prefix the version number
           with 'v'. For example: v0.6.14. Set to 'latest' for the latest
           version.
+      coverage_reporter_platform:
+        type: enum
+        default: "x86_64"
+        description: "Platform of coverage-reporter to use. Supported values: x86_64 (default) and aarch64 (or arm64)"
+        enum: ["x86_64", "aarch64", "arm64"]
     steps:
       - run:
           name: Upload Coverage Results To Coveralls
@@ -141,5 +146,6 @@ commands:
             COVERALLS_MEASURE: << parameters.measure >>
             COVERALLS_FAIL_ON_ERROR: << parameters.fail_on_error >>
             COVERALLS_REPORTER_VERSION: << parameters.coverage_reporter_version >>  # yamllint disable-line rule:line-length
+            COVERALLS_REPORTER_PLATFORM: << parameters.coverage_reporter_platform >>  # yamllint disable-line rule:line-length
             COVERALLS_SOURCE_HEADER: circleci-orb
           command: <<include(scripts/coveralls.sh)>>

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -122,7 +122,9 @@ commands:
       coverage_reporter_platform:
         type: enum
         default: "x86_64"
-        description: "Platform of coverage-reporter to use. Supported values: x86_64 (default) and aarch64 (or arm64)"
+        description: >
+          Platform of coverage-reporter to use. Supported values: x86_64
+          (default) and aarch64 (or arm64).
         enum: ["x86_64", "aarch64", "arm64"]
     steps:
       - run:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -147,7 +147,7 @@ commands:
             COVERALLS_COVERAGE_FORMAT: << parameters.coverage_format >>
             COVERALLS_MEASURE: << parameters.measure >>
             COVERALLS_FAIL_ON_ERROR: << parameters.fail_on_error >>
-            COVERALLS_REPORTER_VERSION: << parameters.coverage_reporter_version >>  # yamllint disable-line rule:line-length
-            COVERALLS_REPORTER_PLATFORM: << parameters.coverage_reporter_platform >>  # yamllint disable-line rule:line-length
+            COVERAGE_REPORTER_VERSION: << parameters.coverage_reporter_version >>  # yamllint disable-line rule:line-length
+            COVERAGE_REPORTER_PLATFORM: << parameters.coverage_reporter_platform >>  # yamllint disable-line rule:line-length
             COVERALLS_SOURCE_HEADER: circleci-orb
           command: <<include(scripts/coveralls.sh)>>

--- a/src/scripts/coveralls.sh
+++ b/src/scripts/coveralls.sh
@@ -55,6 +55,7 @@ esac
 if ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/${platform_filename}" ||
    ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-checksums.txt"; then
   echo "Failed to download coveralls binary or checksum."
+  echo "This may be due to an invalid version: ${COVERAGE_REPORTER_VERSION}. Please check the available versions at https://github.com/coverallsapp/coverage-reporter/releases."
   [ "${COVERALLS_FAIL_ON_ERROR}" != "1" ] && exit 0
   exit 1
 fi

--- a/src/scripts/coveralls.sh
+++ b/src/scripts/coveralls.sh
@@ -96,13 +96,13 @@ if ! tar -xzf "${platform_filename}"; then
   exit 1
 fi
 
-# Check runner architecture for platform match, before any execution attempts, to deliver a helpful error message before a possible shell execution failure:
+# Check architecture compatibility before attempting any execution
 if [ -f ./coveralls ]; then
-  # Get system architecture
   SYSTEM_ARCH=$(uname -m)
-  if [[ "${COVERAGE_REPORTER_PLATFORM}" == "aarch64" && "${SYSTEM_ARCH}" != "aarch64" ]] || \
-     [[ "${COVERAGE_REPORTER_PLATFORM}" == "x86_64" && "${SYSTEM_ARCH}" != "x86_64" ]]; then
-    echo "Error: Architecture mismatch. You specified coverage_reporter_platform: ${COVERAGE_REPORTER_PLATFORM}, but this runner is ${SYSTEM_ARCH}."
+  PLATFORM="${COVERAGE_REPORTER_PLATFORM:-x86_64}" # Default to x86_64 if not set
+  if [[ "${PLATFORM}" == "aarch64" && "${SYSTEM_ARCH}" != "aarch64" ]] || \
+     [[ "${PLATFORM}" == "x86_64" && "${SYSTEM_ARCH}" != "x86_64" ]]; then
+    echo "Error: Architecture mismatch. You specified coverage_reporter_platform: ${PLATFORM}, but this runner is ${SYSTEM_ARCH}."
     [ "${COVERALLS_FAIL_ON_ERROR}" != "1" ] && exit 0
     exit 1
   fi

--- a/src/scripts/coveralls.sh
+++ b/src/scripts/coveralls.sh
@@ -96,6 +96,18 @@ if ! tar -xzf "${platform_filename}"; then
   exit 1
 fi
 
+# Check runner architecture, before any execution attempts, to deliver a helpful error message before a possible shell execution failure:
+if [ -f ./coveralls ]; then
+  # Get system architecture
+  SYSTEM_ARCH=$(uname -m)
+  if [[ "${COVERAGE_REPORTER_PLATFORM}" == "aarch64" && "${SYSTEM_ARCH}" != "aarch64" ]] || \
+     [[ "${COVERAGE_REPORTER_PLATFORM}" == "x86_64" && "${SYSTEM_ARCH}" != "x86_64" ]]; then
+    echo "Error: Architecture mismatch. You specified coverage_reporter_platform: ${COVERAGE_REPORTER_PLATFORM}, but this runner is ${SYSTEM_ARCH}."
+    [ "${COVERALLS_FAIL_ON_ERROR}" != "1" ] && exit 0
+    exit 1
+  fi
+fi
+
 # Ensure the binary exists before attempting to run it
 if [ ! -f ./coveralls ]; then
   echo "Coveralls binary not found after extraction."
@@ -104,7 +116,7 @@ if [ ! -f ./coveralls ]; then
 fi
 
 # Output the version of the installed coverage reporter
-echo "Installed coverage reporter version:"
+echo "Installed coverage reporter version: ${COVERAGE_REPORTER_VERSION}"
 ./coveralls --version || echo "Failed to retrieve version"
 
 # Pass the --debug flag to coverage-reporter if COVERALLS_DEBUG or COVERALLS_VERBOSE (deprecated) is set to "1"

--- a/src/scripts/coveralls.sh
+++ b/src/scripts/coveralls.sh
@@ -99,12 +99,15 @@ fi
 # Check architecture compatibility before attempting any execution
 if [ -f ./coveralls ]; then
   SYSTEM_ARCH=$(uname -m)
-  PLATFORM="${COVERAGE_REPORTER_PLATFORM:-x86_64}" # Default to x86_64 if not set
-  if [[ "${PLATFORM}" == "aarch64" && "${SYSTEM_ARCH}" != "aarch64" ]] || \
-     [[ "${PLATFORM}" == "x86_64" && "${SYSTEM_ARCH}" != "x86_64" ]]; then
-    echo "Error: Architecture mismatch. You specified coverage_reporter_platform: ${PLATFORM}, but this runner is ${SYSTEM_ARCH}."
-    [ "${COVERALLS_FAIL_ON_ERROR}" != "1" ] && exit 0
-    exit 1
+  # For versions >= v0.6.15, we need to check architecture even when platform isn't specified
+  if version_ge "$COVERAGE_REPORTER_VERSION" "v0.6.15"; then
+    if [[ -z "${COVERAGE_REPORTER_PLATFORM}" && "${SYSTEM_ARCH}" != "x86_64" ]] || \
+       [[ "${COVERAGE_REPORTER_PLATFORM}" == "aarch64" && "${SYSTEM_ARCH}" != "aarch64" ]] || \
+       [[ "${COVERAGE_REPORTER_PLATFORM}" == "x86_64" && "${SYSTEM_ARCH}" != "x86_64" ]]; then
+      echo "Error: Architecture mismatch. Platform: ${COVERAGE_REPORTER_PLATFORM:-x86_64}, Runner: ${SYSTEM_ARCH}"
+      [ "${COVERALLS_FAIL_ON_ERROR}" != "1" ] && exit 0
+      exit 1
+    fi
   fi
 fi
 

--- a/src/scripts/coveralls.sh
+++ b/src/scripts/coveralls.sh
@@ -96,7 +96,7 @@ if ! tar -xzf "${platform_filename}"; then
   exit 1
 fi
 
-# Check runner architecture, before any execution attempts, to deliver a helpful error message before a possible shell execution failure:
+# Check runner architecture for platform match, before any execution attempts, to deliver a helpful error message before a possible shell execution failure:
 if [ -f ./coveralls ]; then
   # Get system architecture
   SYSTEM_ARCH=$(uname -m)

--- a/src/scripts/coveralls.sh
+++ b/src/scripts/coveralls.sh
@@ -52,8 +52,8 @@ case "${COVERAGE_REPORTER_PLATFORM}" in
 esac
 
 # Attempt to download the Coveralls binary and checksum file
-if ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/${platform_filename}" ||
-   ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-checksums.txt"; then
+if ! curl -sfLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/${platform_filename}" ||
+   ! curl -sfLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-checksums.txt"; then
   echo "Failed to download coveralls binary or checksum for version: ${COVERAGE_REPORTER_VERSION}."
   echo "This may be due to an invalid version. Please check the available versions at https://github.com/coverallsapp/coverage-reporter/releases."
   [ "${COVERALLS_FAIL_ON_ERROR}" != "1" ] && exit 0
@@ -72,7 +72,7 @@ cat coveralls-checksums.txt
 # Extract expected checksum
 expected_checksum=$(grep "${platform_filename}" coveralls-checksums.txt | awk '{print $1}')
 if [ -z "$expected_checksum" ]; then
-  echo "Failed to extract checksum for ${platform_filename}"
+  echo "Failed to extract checksum for ${platform_filename}. This may indicate an invalid version."
   [ "${COVERALLS_FAIL_ON_ERROR}" != "1" ] && exit 0
   exit 1
 fi

--- a/src/scripts/coveralls.sh
+++ b/src/scripts/coveralls.sh
@@ -51,11 +51,11 @@ case "${COVERAGE_REPORTER_PLATFORM}" in
     ;;
 esac
 
-# Download the Coveralls binary and checksum file
+# Attempt to download the Coveralls binary and checksum file
 if ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/${platform_filename}" ||
    ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-checksums.txt"; then
-  echo "Failed to download coveralls binary or checksum."
-  echo "This may be due to an invalid version: ${COVERAGE_REPORTER_VERSION}. Please check the available versions at https://github.com/coverallsapp/coverage-reporter/releases."
+  echo "Failed to download coveralls binary or checksum for version: ${COVERAGE_REPORTER_VERSION}."
+  echo "This may be due to an invalid version. Please check the available versions at https://github.com/coverallsapp/coverage-reporter/releases."
   [ "${COVERALLS_FAIL_ON_ERROR}" != "1" ] && exit 0
   exit 1
 fi

--- a/src/scripts/coveralls.sh
+++ b/src/scripts/coveralls.sh
@@ -6,10 +6,10 @@ if [ "${COVERALLS_DEBUG}" == "1" ] || [ "${COVERALLS_VERBOSE}" == "1" ]; then
 fi
 
 # Determine which version of coverage-reporter to download
-if [ -z "$COVERALLS_REPORTER_VERSION" ] || [ "$COVERALLS_REPORTER_VERSION" == "latest" ]; then
+if [ -z "$COVERAGE_REPORTER_VERSION" ] || [ "$COVERAGE_REPORTER_VERSION" == "latest" ]; then
   asset_path="latest/download"
 else
-  asset_path="download/${COVERALLS_REPORTER_VERSION}"
+  asset_path="download/${COVERAGE_REPORTER_VERSION}"
 fi
 
 # Determine the platform-specific filename:

--- a/src/scripts/coveralls.sh
+++ b/src/scripts/coveralls.sh
@@ -12,12 +12,85 @@ else
   asset_path="download/${COVERALLS_REPORTER_VERSION}"
 fi
 
-# Download the Coveralls binary and verify the checksum
-if ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-linux.tar.gz" ||
-   ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-checksums.txt" ||
-   ! grep coveralls-linux.tar.gz coveralls-checksums.txt | sha256sum --check ||
-   ! tar -xzf coveralls-linux.tar.gz; then
-  echo "Failed to download or verify coveralls binary."
+# Determine the platform-specific filename:
+# This logic is necessary due to the introduction of multiple platform support starting from v0.6.15.
+# It selects the correct filename based on the specified platform, and version, while ensuring
+# backward compatibility with earlier versions that only supported a generic Linux binary (for x86_64).
+
+# Function to compare version numbers
+version_ge() {
+  # Compare two version numbers
+  [ "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1" ]
+}
+
+# Determine platform-specific filename
+case "${COVERAGE_REPORTER_PLATFORM}" in
+  x86_64|"")
+    if version_ge "$COVERAGE_REPORTER_VERSION" "v0.6.15"; then
+      platform_filename="coveralls-linux-x86_64.tar.gz"
+    else
+      platform_filename="coveralls-linux.tar.gz"
+    fi
+    ;;
+  aarch64|arm64)
+    if version_ge "$COVERAGE_REPORTER_VERSION" "v0.6.15"; then
+      platform_filename="coveralls-linux-aarch64.tar.gz"
+    else
+      echo "Warning: The aarch64/arm64 platform is only supported from version v0.6.15 onwards. Proceeding with v0.6.15." >&2
+      asset_path="download/v0.6.15"
+      platform_filename="coveralls-linux-aarch64.tar.gz"
+    fi
+    ;;
+  *)
+    echo "Warning: Unsupported platform: ${COVERAGE_REPORTER_PLATFORM}. The default x86_64 version will be used." >&2
+    if version_ge "$COVERAGE_REPORTER_VERSION" "v0.6.15"; then
+      platform_filename="coveralls-linux-x86_64.tar.gz"
+    else
+      platform_filename="coveralls-linux.tar.gz"
+    fi
+    ;;
+esac
+
+# Download the Coveralls binary and checksum file
+if ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/${platform_filename}" ||
+   ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-checksums.txt"; then
+  echo "Failed to download coveralls binary or checksum."
+  [ "${COVERALLS_FAIL_ON_ERROR}" != "1" ] && exit 0
+  exit 1
+fi
+
+# Verify the downloaded binary:
+# The following code was chosen to replace the more simple `sha256sum -c` because it provides
+# clearer debugging information re: our matrix of supported coverage-reporter versions and platforms.
+# We may drop back to `${platform_filename}" coveralls-checksums.txt | sha256sum -c` when we're more confidently handling these.
+
+# DEBUG: Print contents of checksum file for debugging
+echo "Contents of coveralls-checksums.txt:"
+cat coveralls-checksums.txt
+
+# Extract expected checksum
+expected_checksum=$(grep "${platform_filename}" coveralls-checksums.txt | awk '{print $1}')
+if [ -z "$expected_checksum" ]; then
+  echo "Failed to extract checksum for ${platform_filename}"
+  [ "${COVERALLS_FAIL_ON_ERROR}" != "1" ] && exit 0
+  exit 1
+fi
+
+# Compute actual checksum
+actual_checksum=$(sha256sum "${platform_filename}" | awk '{print $1}')
+
+# Perform verification by comparing expected and actual checksums
+if [ "$expected_checksum" != "$actual_checksum" ]; then
+  echo "Checksum verification failed."
+  echo "Expected: $expected_checksum"
+  echo "Actual: $actual_checksum"
+  [ "${COVERALLS_FAIL_ON_ERROR}" != "1" ] && exit 0
+  exit 1
+fi
+
+# Extract / install the binary
+if ! tar -xzf "${platform_filename}"; then
+  echo "Failed to extract coveralls binary."
   [ "${COVERALLS_FAIL_ON_ERROR}" != "1" ] && exit 0
   exit 1
 fi


### PR DESCRIPTION
## Description

Add `coverage_reporter_platform` parameter with logic to download and use the appropriate architecture-specific binary of `coverage-reporter`. 

## To Do

- [x] Add `coverage_reporter_platform` parameter and logic to use architecture-specific binary of `coverage-reporter`.
- [x] Modify tests to test `coverage_reporter_platform`.